### PR TITLE
Added a tool that prints the Hive username and password from inside a…

### DIFF
--- a/java/src/main/java/com/anaconda/skein/UserTools.java
+++ b/java/src/main/java/com/anaconda/skein/UserTools.java
@@ -1,0 +1,36 @@
+package com.anaconda.skein;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.token.Token;
+import java.io.File;
+import java.io.IOException;
+
+public class UserTools {
+    final static String hiveTokenKind = "HIVE_DELEGATION_TOKEN";
+
+    // Print from the Delegation Token file the Username (Identifier) and Password.
+    // With user + password you can create a Hive connection
+    private static void printDelegationTokenIdandPassForHive(String tokenFilepath) throws IOException {
+        Credentials credentials = Credentials.readTokenStorageFile(new File(tokenFilepath), null);
+        for(Token t : credentials.getAllTokens()) {
+            if(t.getKind().toString().equals(hiveTokenKind)) {
+                String username = new String(Base64.encodeBase64(t.getIdentifier()));
+                String password = new String(Base64.encodeBase64(t.getPassword()));
+                System.out.println( username + "\n" + password);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        String help = "Usage: To print username and password from inside the Hive delegation token: \n" +
+                "[print-hive-user-pass]" + "<delegation-token-file-path>";
+
+        switch(args[0]) {
+            case "print-hive-user-pass": UserTools.printDelegationTokenIdandPassForHive(args[1]);
+                                            break;
+            default: System.out.println(help);
+                     System.exit(1);
+        }
+    }
+}

--- a/java/src/main/java/com/anaconda/skein/UserTools.java
+++ b/java/src/main/java/com/anaconda/skein/UserTools.java
@@ -10,7 +10,8 @@ public class UserTools {
     final static String hiveTokenKind = "HIVE_DELEGATION_TOKEN";
 
     // Print from the Delegation Token file the Username (Identifier) and Password.
-    // With user + password you can create a Hive connection
+    // With user + password you can create a Hive connection.
+    // You can see an example here of how to use them: https://github.com/dropbox/PyHive/pull/321
     private static void printDelegationTokenIdandPassForHive(String tokenFilepath) throws IOException {
         Credentials credentials = Credentials.readTokenStorageFile(new File(tokenFilepath), null);
         for(Token t : credentials.getAllTokens()) {


### PR DESCRIPTION
I'm storing this pull request here because I prefer to have another pull-request merged first:
https://github.com/jcrist/skein/pull/210 (afterward I would like to merge this as well to the original skein project)

The context: I would like to be able to connect to Hive using a pure-python library ([PyHive](https://github.com/dropbox/PyHive)) and authenticate with the Hive Delegation Token.

The problem: The Hadoop delegation token file is written in Hadoop Text format([gihub-link1](https://github.com/opencore/hadoop-token-file-utils), [stackoverflow-link1](https://stackoverflow.com/questions/19851665/difference-between-text-and-string-in-hadoop))

I would like to have a small tool based on the same idea as the `gihub-link1` repo above as part of the skein library.
The alternative is re-implementing a File Reader in Python. That is a big effort that I would like to avoid. 

I think that this approach is similar to PySpark. There there is a connection (gateway) between the Python program and the one running on JVM. (I couldn't find the code that gets the credentials through the gateway, but I can look again.)

I wrote the code with a self-centered view, only addressing my specific problem because to me it looks like each database has its own way of authenticating and I didn't spend the time to read&understand all of them to be able to write a generic tool here. I assume that this code will evolve to be more generic in the future.

As always I appreciate any feedback. 